### PR TITLE
tiv: TerminalImageViewer, git HEAD (commit 53dff6f5)

### DIFF
--- a/tiv/Makefile
+++ b/tiv/Makefile
@@ -1,0 +1,57 @@
+##
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tiv
+PKG_REV:=53dff6f5b933d0aa883868efb9e47d48c2ca6c4f
+PKG_VERSION:=1.0.0-git-$(shell echo "$(PKG_REV)" | cut -c1-7)
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/stefanhaustein/TerminalImageViewer.git
+PKG_SOURCE_VERSION:=$(PKG_REV)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+#PKG_MIRROR_HASH:=25c2729b8a683b1d982e5d939ca6743d448d43edbeba66f4d25ef534e9a2c907
+PKG_MAINTAINER:=Thomas Kupper <thomas.kupper@gmail.com>
+PKG_LICENSE:=GPLv2
+
+PKG_INSTALL=0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/tiv
+  SECTION:=devel
+  CATEGORY:=Utilities
+  TITLE:=Program to display images in a terminal
+  URL:=https://github.com/stefanhaustein/TerminalImageViewer
+  DEPENDS:=libstdcpp
+endef
+
+define Package/tiv/description
+  Small C++ program to display images in a (modern) terminal using RGB ANSI codes
+  and unicode block graphics characters
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(CP) $(PKG_BUILD_DIR)/src/main/cpp/* $(PKG_BUILD_DIR)/
+endef
+
+define Build/Compile
+	$(MAKE) $(PKG_JOBS) \
+		CXX=$(TARGET_CXX) CPPFLAGS="$(TARGET_CPPFLAGS)" \
+		LDFLAGS="$(TARGET_LDFLAGS)" -C $(PKG_BUILD_DIR) all
+endef
+
+define Package/tiv/install
+	$(INSTALL_DIR) $(1)/opt/bin
+	$(CP) $(PKG_BUILD_DIR)/tiv $(1)/opt/bin/
+endef
+
+$(eval $(call BuildPackage,tiv))

--- a/tiv/Makefile
+++ b/tiv/Makefile
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2015 OpenWrt.org
+# Copyright (C) 2015-2019 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -17,7 +17,7 @@ PKG_SOURCE_URL:=https://github.com/stefanhaustein/TerminalImageViewer.git
 PKG_SOURCE_VERSION:=$(PKG_REV)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-#PKG_MIRROR_HASH:=25c2729b8a683b1d982e5d939ca6743d448d43edbeba66f4d25ef534e9a2c907
+PKG_MIRROR_HASH:=bc32ada3817a6a171cc2ec446c8b9d365a195a1761870e3bd85d876ec19e79c8
 PKG_MAINTAINER:=Thomas Kupper <thomas.kupper@gmail.com>
 PKG_LICENSE:=GPLv2
 

--- a/tiv/Makefile
+++ b/tiv/Makefile
@@ -1,5 +1,5 @@
 ##
-# Copyright (C) 2015-2019 OpenWrt.org
+# Copyright (C) 2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,16 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tiv
-PKG_REV:=53dff6f5b933d0aa883868efb9e47d48c2ca6c4f
-PKG_VERSION:=1.0.0-git-$(shell echo "$(PKG_REV)" | cut -c1-7)
+PKG_SOURCE_DATE:=2019-04-01
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/stefanhaustein/TerminalImageViewer.git
-PKG_SOURCE_VERSION:=$(PKG_REV)
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_MIRROR_HASH:=bc32ada3817a6a171cc2ec446c8b9d365a195a1761870e3bd85d876ec19e79c8
+PKG_SOURCE_VERSION:=53dff6f5b933d0aa883868efb9e47d48c2ca6c4f
+PKG_MIRROR_HASH:=25c2729b8a683b1d982e5d939ca6743d448d43edbeba66f4d25ef534e9a2c907
+
 PKG_MAINTAINER:=Thomas Kupper <thomas.kupper@gmail.com>
 PKG_LICENSE:=GPLv2
 


### PR DESCRIPTION
Compile tested: for all available platform (aarch64-3.10, armv5-3.2, armv7-2.6, armv7-3.2, mips-3.4, mipsel-3.4, x64-3.2) compiled on Ubuntu 16.04 virtual machine

Run tested: QNAP TS-251 (x64) and Synology EDS14 (armv7-2.6). Tested showing all pictures in a directory (thumbnail mode). And of course showing actual pictures (gif, jpeg, png).

[TerminalImageViewer github/home page](https://github.com/stefanhaustein/TerminalImageViewer)