### PR TITLE
hlspxd: fix comments, typos, MSVC build

### DIFF
--- a/hlspxd/src/platform.cpp
+++ b/hlspxd/src/platform.cpp
@@ -34,7 +34,7 @@ int HideSignals()
 	return 0;
 }
 
-Exception::Exception(const char * const &format, ...) throw()
+Exception::Exception(const char * format, ...) throw()
 {
 	_message = NULL;
 	int size = 0;

--- a/hlspxd/src/platform.h
+++ b/hlspxd/src/platform.h
@@ -29,7 +29,7 @@ class Exception : public std::exception
 {
 	char *_message;
 public:
-	Exception(const char * const &format, ...) throw();
+	Exception(const char * format, ...) throw();
 	virtual ~Exception() throw() { delete[] _message; }
 	virtual const char *what() const throw() { return _message; }
 };

--- a/hlspxd/src/utils.cpp
+++ b/hlspxd/src/utils.cpp
@@ -17,7 +17,7 @@ void LogWriter::WriteBuf(const char *message)
 
 	FILE *logfil = fopen(LogFileName.c_str(), "a+t");
 	if (!logfil) {
-		std::cerr << "fopen failed, filename " << LogFileName << ", errno " << errno << std::endl;
+		std::cerr << "fopen() failed, filename " << LogFileName << ": " << strerror(errno) << std::endl;
 		std::terminate();
 	}
 	fprintf(logfil, "%02d-%02d-%02dT%02d:%02d:%02d (%d) - %s\n",

--- a/hlspxd/src/utils.h
+++ b/hlspxd/src/utils.h
@@ -16,7 +16,7 @@ static inline void rtrim(std::string &s) {
 		std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
 }
 
-// копировать все в строку
+// copy src contents to string
 size_t copyToString(std::istream &src, std::string& str);
 
 class LogWriter
@@ -129,7 +129,7 @@ public:
 };
 
 
-// streambuf для сокета
+// socket streambuf
 class socketbuf
 	: public std::streambuf
 {
@@ -320,7 +320,7 @@ public:
 	inline std::string &getPath(){ return _path; }
 };
 
-class HttpResponce : public HttpMessage
+class HttpResponse : public HttpMessage
 {
 	//static const char *dayOfWeek[];
 	//static const char *MonthName[];
@@ -371,10 +371,10 @@ public:
 		//HTTP_VERSION_NOT_SUPPORTED = 505
 	};
 
-	HttpResponce()
+	HttpResponse()
 		:_status(HTTP_OK), _reason("OK")
 	{}
-	HttpResponce(socketstream &socstr);
+	HttpResponse(socketstream &socstr);
 
 	size_t getContentLength();
 	inline HttpStatus getStatus() const { return _status; }
@@ -400,7 +400,7 @@ class HttpClient
 public:
 	HttpClient(){}
 	~HttpClient(){ _sockstream.close(); }
-	HttpResponce getResponce(Uri &reqUri);
+	HttpResponse getResponse(Uri &reqUri);
 	socketstream &getStream(){ return _sockstream; }
 	inline bool connected(){ return _sockstream.good(); }
 	inline void abort(){ _sockstream.close(); }

--- a/hlspxd/src/videoviewer.h
+++ b/hlspxd/src/videoviewer.h
@@ -3,22 +3,22 @@
 
 #include "utils.h"
 #include <list>
-// запись в m3u8 файле
+// entry in m3u8 file
 struct PlayListRecord
 {
-	std::string Tag;					// таг - обязательно есть
-	std::vector<std::string> Attributes;	// атрибуты
-	Uri TsUri;					// URL - абсолютный или относительный
+	std::string Tag;					// tag - required field
+	std::vector<std::string> Attributes;	// attributes
+	Uri TsUri;					// URL - absolute or relative
 };
 
-// для выбора нужного разрешения показа
-struct StremInf
+// used to select the required stream resolution
+struct StreamInf
 {
-	int Bandwidth;				// разрешение
-	Uri TsUri;					// URL - абсолютный или относительный
-	StremInf() :Bandwidth(0) {}
+	int Bandwidth;				// resolution
+	Uri TsUri;					// URL - absolute or relative
+	StreamInf() :Bandwidth(0) {}
 
-	bool operator < (const StremInf &other) const
+	bool operator < (const StreamInf &other) const
 	{
 		return Bandwidth < other.Bandwidth;
 	}
@@ -27,7 +27,7 @@ struct StremInf
 class TsURI : public Uri
 {
 public:
-	double	Duration;						// время показа файла (sec)
+	double	Duration;						// total played duration (sec)
 	TsURI()
 		:Duration(0)
 	{}
@@ -74,19 +74,19 @@ struct TsPacketHdr
 
 class VideoViewer
 {
-	socketstream VideoStream;			// выходной поток
-	VideoQuality SessionQuality;		// качество показа видео
-	Uri VideoUri;						// URI который показываем
-	HttpClient M3U8Client;				// сессия сервера контента
-	char TsBuf[TS_BUF_LEN];				// выходной буфер
+	socketstream VideoStream;			// output stream
+	VideoQuality SessionQuality;		// video quality
+	Uri VideoUri;						// current URI
+	HttpClient M3U8Client;				// content server session
+	char TsBuf[TS_BUF_LEN];				// output buffer
 
-	// парсер
+	// parser
 	static std::regex PlRx;				//15 = file
-	std::vector<PlayListRecord> PlayList;	// собственно плейлист
+	std::vector<PlayListRecord> PlayList;	// playlist
 
-	int	MaxHistLen;				// длина истории
+	int	MaxHistLen;				// history length
 
-	std::list<TsURI> TsList;			// список ТС файлов
+	std::list<TsURI> TsList;			// TS file list
 
 	HttpClient tsClient;
 


### PR DESCRIPTION
Compile tested: x64-3.2
Run tested: Ubuntu 18.04 container x64. Tested general functionality with a sample playlist.

- Fix typos and translate comments
- Remove redundant `const &` for `const char *`, which fixes MSVC build
- Add `std::terminate` and print to `cerr` if logfile cannot be opened
