### PR TITLE
hlspxd: support for Samsung Orsay TVs (from 2014), tested on H5570

### DIFF
--- a/hlspxd/patches/200-samsung-orsay-support.patch
+++ b/hlspxd/patches/200-samsung-orsay-support.patch
@@ -1,0 +1,116 @@
+From 1c4ced0f8a982f77f942d642d2b7bfa4ed576414 Mon Sep 17 00:00:00 2001
+From: Julius Schwartzenberg <julius.schwartzenberg@gmail.com>
+Date: Thu, 30 May 2019 18:04:31 +0200
+Subject: [PATCH 1/2] HTTP HEAD method support
+
+Samsung Orsay TVs (from 2014) require this, tested on H5570.
+---
+ hlspxd/src/utils.cpp       | 3 ++-
+ hlspxd/src/utils.h         | 2 ++
+ hlspxd/src/videoviewer.cpp | 6 ++++++
+ hlspxd/src/videoviewer.h   | 1 +
+ 4 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/hlspxd/src/utils.cpp b/hlspxd/src/utils.cpp
+index df022c8..858b21d 100644
+--- a/hlspxd/src/utils.cpp
++++ b/hlspxd/src/utils.cpp
+@@ -212,7 +212,7 @@ const std::string *HttpMessage::getHeaderRecord(std::string key)
+ 	return &(it->second);
+ }
+ 
+-std::regex HttpRequest::reqRx("(GET|get)[[:space:]]+([^[:space:]]+)[[:space:]]+(.+)");
++std::regex HttpRequest::reqRx("(GET|get|HEAD|head)[[:space:]]+([^[:space:]]+)[[:space:]]+(.+)");
+ 
+ HttpRequest::HttpRequest(istream& stream)
+ {
+@@ -227,6 +227,7 @@ HttpRequest::HttpRequest(istream& stream)
+ 
+ 	if (!regex_search(inStr.c_str(), res, reqRx)) throw Exception("bad request");
+ 
++	_method = res[1].str();
+ 	_path = res[2].str();
+ 
+ 	HttpMessage::init(stream);
+diff --git a/hlspxd/src/utils.h b/hlspxd/src/utils.h
+index 3391311..780e46c 100644
+--- a/hlspxd/src/utils.h
++++ b/hlspxd/src/utils.h
+@@ -314,9 +314,11 @@ public:
+ class HttpRequest : public HttpMessage
+ {
+ 	static std::regex reqRx;
++	std::string _method;
+ 	std::string _path;
+ public:
+ 	HttpRequest(std::istream& stream);
++	inline std::string &getMethod(){ return _method; }
+ 	inline std::string &getPath(){ return _path; }
+ };
+ 
+diff --git a/hlspxd/src/videoviewer.cpp b/hlspxd/src/videoviewer.cpp
+index 4aeac2c..cfc9161 100644
+--- a/hlspxd/src/videoviewer.cpp
++++ b/hlspxd/src/videoviewer.cpp
+@@ -25,6 +25,7 @@ VideoViewer::VideoViewer(SOCKET ClientSocket)
+ 	HttpRequest req(VideoStream);
+ 
+ 	string reqStr;
++	Uri::decode(req.getMethod(), httpReqMethod);
+ 	Uri::decode(req.getPath(), reqStr);
+ 
+ 	string reqUri = reqStr;
+@@ -134,6 +135,11 @@ void VideoViewer::Run()
+ 	VideoStream << "HTTP/1.1 200 OK\nServer: hlspxd\nContent-Type: application/octet-stream\nConnection : close\n\n";
+ 	VideoStream.flush();
+ 
++	if (httpReqMethod == "HEAD" || httpReqMethod == "head")
++	{
++		return;
++	}
++
+ 	// find redirections to different resolutions
+ 	vector<StreamInf> streamVec;
+ 
+diff --git a/hlspxd/src/videoviewer.h b/hlspxd/src/videoviewer.h
+index d8775c5..5309a1c 100644
+--- a/hlspxd/src/videoviewer.h
++++ b/hlspxd/src/videoviewer.h
+@@ -76,6 +76,7 @@ class VideoViewer
+ {
+ 	socketstream VideoStream;			// output stream
+ 	VideoQuality SessionQuality;		// video quality
++	std::string httpReqMethod;			// HTTP request method
+ 	Uri VideoUri;						// current URI
+ 	HttpClient M3U8Client;				// content server session
+ 	char TsBuf[TS_BUF_LEN];				// output buffer
+-- 
+2.17.1
+
+
+From 5c266b53cc11a0d197892bd5e6b1cef4e220d349 Mon Sep 17 00:00:00 2001
+From: Julius Schwartzenberg <julius.schwartzenberg@gmail.com>
+Date: Thu, 30 May 2019 18:07:14 +0200
+Subject: [PATCH 2/2] Change HTTP response header to double byte \r\n newline
+
+Samsung Orsay TVs (from 2014) require this, tested on H5570.
+---
+ hlspxd/src/videoviewer.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hlspxd/src/videoviewer.cpp b/hlspxd/src/videoviewer.cpp
+index cfc9161..5b7e7f2 100644
+--- a/hlspxd/src/videoviewer.cpp
++++ b/hlspxd/src/videoviewer.cpp
+@@ -132,7 +132,7 @@ void VideoViewer::Run()
+ {	
+ 	ReadM3U8();		// parse preliminary
+ 	// successful - send the response to TV
+-	VideoStream << "HTTP/1.1 200 OK\nServer: hlspxd\nContent-Type: application/octet-stream\nConnection : close\n\n";
++	VideoStream << "HTTP/1.1 200 OK\r\nServer: hlspxd\r\nContent-Type: application/octet-stream\r\nConnection : close\r\n\r\n";
+ 	VideoStream.flush();
+ 
+ 	if (httpReqMethod == "HEAD" || httpReqMethod == "head")
+-- 
+2.17.1
+


### PR DESCRIPTION
Compile tested: AMD64 (Ubuntu 18.04), ARMv6 (Raspbian 9.9)
Run tested: AMD64 (Ubuntu 18.04), ARMv6 (Raspbian 9.9), tested by playing multiple video streams on my Samsung TV and VLC through hlspxd