### PR TITLE
qt5: add ssl support 

### DIFF
--- a/qt5/Makefile
+++ b/qt5/Makefile
@@ -53,7 +53,7 @@ endef
 define Package/qt5-network
 	$(call Package/qt5/Default)
 	TITLE+=network
-	DEPENDS+=+qt5-core
+	DEPENDS+=+qt5-core +libopenssl
 endef
 
 define Package/qt5-xml

--- a/qt5/Makefile
+++ b/qt5/Makefile
@@ -68,6 +68,7 @@ define Build/Configure
 	( cd $(PKG_BUILD_DIR) ; \
 		./configure \
 			-prefix /opt \
+			-I $(STAGING_DIR)/opt/include \
 			-extprefix $(TOOLCHAIN_DIR) \
 			-sysroot $(TOOLCHAIN_DIR) \
 			-plugindir /opt/lib/Qt/plugins \


### PR DESCRIPTION
It seems that the header files of openssl library couldn't be correctly located and loaded during the building process of qt5. This change should fix it and make sure the compiled qt5-network library has ssl support. You could check build_dir/target-..../qt-everywhere-src-5.14.0/config.summary after compiling to verify it. (OpenSSL and OpenSSL 1.1 under Build options will show yes instead of no.)