### PR TITLE
tunsafe: new package

### DIFF
--- a/tunsafe/Makefile
+++ b/tunsafe/Makefile
@@ -1,0 +1,95 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tunsafe
+PKG_VERSION:=1.5rc2
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/TunSafe/TunSafe.git
+PKG_SOURCE_DATE:=2018-12-17
+PKG_SOURCE_VERSION:=85a871c1d226956df7c1308a1e5527556fe35fe1
+PKG_MIRROR_HASH:=7db72774b760f9ab30bb5e8aee20973c638b4e4ee495d578e0cac26e90c15ffe
+
+PKG_MAINTAINER:=Raif Atef <beliskner.github.3psil0N@neverbox.com>
+PKG_LICENSE:=AGPL-1.0-only
+PKG_LICENSE_FILES:=LICENSE.AGPL.TXT
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/tunsafe
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=VPN
+  TITLE:=TunSafe
+  URL:=https://www.tunsafe.com/
+  DEPENDS:=+librt +libstdcpp +(TARGET_armv5_3_2||TARGET_x86_2_6||TARGET_mips_3_4||TARGET_mipsel_3_4):libatomic
+endef
+
+define Package/tunsafe/description
+A high performance and secure VPN client that uses the WireGuard protocol. TunSafe makes 
+it extremely simple to setup blazingly fast and secure VPN tunnels between Windows and Linux.
+This is a user-mode implementation that also supports non-standard obfuscation and TCP mode.
+endef
+
+ifeq ($(ARCH),arm)
+  TUNSAFE_EXTRA_FILES+= \
+  	crypto/chacha20/chacha20-arm-linux.S \
+  	crypto/poly1305/poly1305-arm-linux.S
+else ifeq ($(ARCH),x86_64)
+  TUNSAFE_EXTRA_FILES+= \
+	crypto/aesgcm/aesni_gcm-x64-linux.s \
+	crypto/aesgcm/aesni-x64-linux.s \
+	crypto/aesgcm/ghash-x64-linux.s \
+	crypto/poly1305/poly1305-x64-linux.s \
+	crypto/chacha20/chacha20-x64-linux.s
+else
+  TUNSAFE_EXTRA_CFLAGS+=-DCHACHA20_WITH_ASM=0 -DBLAKE2S_WITH_ASM=0
+endif
+
+ifneq ($(findstring xarmv5,x$(BOARD)),)
+  TUNSAFE_REQUIRES_LIBATOMIC:=1
+endif
+
+ifeq ($(ARCH),i386)
+  TUNSAFE_REQUIRES_LIBATOMIC:=1
+endif
+
+ifeq ($(ARCH),mips)
+  TUNSAFE_REQUIRES_LIBATOMIC:=1
+endif
+
+ifeq ($(ARCH),mipsel)
+  TUNSAFE_REQUIRES_LIBATOMIC:=1
+endif
+
+ifdef TUNSAFE_REQUIRES_LIBATOMIC
+  TUNSAFE_EXTRA_LDFLAGS+=-latomic
+endif
+
+define Build/Compile
+	cd $(PKG_BUILD_DIR) && $(TARGET_CXX) -I. -DNDEBUG -DWITH_NETWORK_BSD=1 \
+		$(TUNSAFE_EXTRA_CFLAGS) -pthread -lrt -std=c++11 $(TUNSAFE_EXTRA_LDFLAGS) \
+		$(TARGET_LDFLAGS) $(TUNSAFE_EXTRA_FILES) tunsafe_amalgam.cpp -o tunsafe;
+	cd $(PKG_BUILD_DIR) && $(STRIP) tunsafe
+endef
+
+define Build/Install
+endef
+
+define Package/tunsafe/install
+	$(INSTALL_DIR) $(1)/opt/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tunsafe $(1)/opt/sbin
+	$(INSTALL_DIR) $(1)/opt/etc/tunsafe
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/installer/TunSafe.conf $(1)/opt/etc/tunsafe/main.conf
+	$(INSTALL_DIR) $(1)/opt/etc/init.d
+	$(INSTALL_BIN) ./files/S30tunsafe $(1)/opt/etc/init.d
+endef
+
+define Package/tunsafe/conffiles
+/opt/etc/tunsafe/main.conf
+endef
+
+$(eval $(call BuildPackage,tunsafe))

--- a/tunsafe/files/S30tunsafe
+++ b/tunsafe/files/S30tunsafe
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+ENABLED=yes
+PROCS=tunsafe
+ARGS="/opt/etc/tunsafe/main.conf"
+PREARGS=""
+DESC=$PROCS
+PATH=/opt/sbin:/opt/bin:/opt/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[ -z "$(which $PROCS)" ] && exit 0
+
+. /opt/etc/init.d/rc.func

--- a/tunsafe/patches/0001-compile-error-fix.diff
+++ b/tunsafe/patches/0001-compile-error-fix.diff
@@ -1,0 +1,14 @@
+diff --git a/tunsafe_bsd.cpp b/tunsafe_bsd.cpp
+index 17f855c..2772d06 100644
+--- a/tunsafe_bsd.cpp
++++ b/tunsafe_bsd.cpp
+@@ -36,7 +36,7 @@
+ #include <net/if_tun.h>
+ #include <net/if_dl.h>
+ #elif defined(OS_LINUX)
+-#include <linux/if.h>
++// #include <linux/if.h>
+ #include <linux/if_tun.h>
+ #include <sys/prctl.h>
+ #include <linux/rtnetlink.h> 
+

--- a/tunsafe/patches/0002-arm-neon-detection.diff
+++ b/tunsafe/patches/0002-arm-neon-detection.diff
@@ -1,0 +1,17 @@
+diff --git a/tunsafe_cpu.h b/tunsafe_cpu.h
+index c19f6b1..2347ce3 100644
+--- a/tunsafe_cpu.h
++++ b/tunsafe_cpu.h
+@@ -32,7 +32,11 @@ extern uint32 x86_pcap[3];
+ 
+ extern uint32 arm_pcap[1];
+ 
+-#define ARM_PCAP_NEON (arm_pcap[0] & (1 << 0))
++#if defined(__ARM_NEON__) || defined(__ARM_NEON)
++	#define ARM_PCAP_NEON (arm_pcap[0] & (1 << 0))
++#else
++	#define ARM_PCAP_NEON 0
++#endif
+ 
+ #endif  // defined(ARCH_CPU_ARM_FAMILY)
+ 

--- a/tunsafe/patches/0003-handle-different-paths-of-ip.diff
+++ b/tunsafe/patches/0003-handle-different-paths-of-ip.diff
@@ -1,0 +1,60 @@
+diff --git a/tunsafe_bsd.cpp b/tunsafe_bsd.cpp
+index 17f855c..eb158db 100644
+--- a/tunsafe_bsd.cpp
++++ b/tunsafe_bsd.cpp
+@@ -367,9 +367,9 @@ static void AddOrRemoveRoute(const RouteInfo &cd, bool remove) {
+   const char *cmd = remove ? "del" : "add";
+   const char *proto = (cd.family == AF_INET) ? NULL : "-6";
+   if (cd.dev.empty()) {
+-    RunCommand("/sbin/ip %s route %s %s via %s", proto, cmd, buf1, buf2);
++    RunCommand("ip %s route %s %s via %s", proto, cmd, buf1, buf2);
+   } else {
+-    RunCommand("/sbin/ip %s route %s %s dev %s", proto, cmd, buf1, cd.dev.c_str());
++    RunCommand("ip %s route %s %s dev %s", proto, cmd, buf1, cd.dev.c_str());
+   }
+ #elif defined(OS_MACOSX) || defined(OS_FREEBSD)
+   const char *cmd = remove ? "delete" : "add";
+@@ -436,10 +436,10 @@ bool TunsafeBackendBsd::Configure(const TunConfig &&config, TunConfigOut *out) o
+   addresses_to_remove_ = config.addresses;
+ 
+ #if defined(OS_LINUX)
+-  RunCommand("/sbin/ip address flush dev %s scope global", devname_);
++  RunCommand("ip address flush dev %s scope global", devname_);
+   for(const WgCidrAddr &a : config.addresses)
+-    RunCommand("/sbin/ip address add dev %s %s", devname_, print_ip_prefix(buf, a.size == 32 ? AF_INET : AF_INET6, a.addr, a.cidr));
+-  RunCommand("/sbin/ip link set dev %s mtu %d up", devname_, config.mtu);
++    RunCommand("ip address add dev %s %s", devname_, print_ip_prefix(buf, a.size == 32 ? AF_INET : AF_INET6, a.addr, a.cidr));
++  RunCommand("ip link set dev %s mtu %d up", devname_, config.mtu);
+ #else
+   for(const WgCidrAddr &a : config.addresses) {
+     if (a.size == 32) {
+@@ -515,7 +515,7 @@ void TunsafeBackendBsd::CleanupRoutes() {
+ 
+ #if defined(OS_LINUX)
+   for(const WgCidrAddr &a : addresses_to_remove_)
+-    RunCommand("/sbin/ip address del dev %s %s", devname_, print_ip_prefix(buf, a.size == 32 ? AF_INET : AF_INET6, a.addr, a.cidr));
++    RunCommand("ip address del dev %s %s", devname_, print_ip_prefix(buf, a.size == 32 ? AF_INET : AF_INET6, a.addr, a.cidr));
+ #else
+   for(const WgCidrAddr &a : addresses_to_remove_) {
+     if (a.size == 32) {
+diff --git a/util.cpp b/util.cpp
+index 11add66..5e0ff27 100644
+--- a/util.cpp
++++ b/util.cpp
+@@ -148,7 +148,6 @@ int RunCommand(const char *fmt, ...) {
+   std::string tmp;
+   char buf[32], c;
+   char *args[33];
+-  char *envp[1] = {NULL};
+   int nargs = 0;
+   bool didadd = false;
+   va_start(va, fmt);
+@@ -194,7 +193,7 @@ ZERO:
+ #if defined(OS_POSIX)
+   pid_t pid = fork();
+   if (pid == 0) {
+-    execve(args[0], args, envp);
++    execvp(args[0], args);
+     exit(127);
+   }
+   if (pid < 0) {

--- a/tunsafe/patches/0004-disable-thread-rename.diff
+++ b/tunsafe/patches/0004-disable-thread-rename.diff
@@ -1,0 +1,13 @@
+diff --git a/tunsafe_bsd.cpp b/tunsafe_bsd.cpp
+index 17f855c..04ee3a3 100644
+--- a/tunsafe_bsd.cpp
++++ b/tunsafe_bsd.cpp
+@@ -837,7 +837,7 @@ int main(int argc, char **argv) {
+   InitOsxGetMilliseconds();
+ #endif
+ 
+-  SetThreadName("tunsafe-m");
++  // SetThreadName("tunsafe-m");
+ 
+   TunsafeBackendBsdImpl backend;
+   if (cmd.interface_name)

--- a/tunsafe/patches/0005-fix-x86-sse-detection.diff
+++ b/tunsafe/patches/0005-fix-x86-sse-detection.diff
@@ -1,0 +1,16 @@
+ crypto/blake2s/blake2s.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/crypto/blake2s/blake2s.cpp b/crypto/blake2s/blake2s.cpp
+index 840720e..632e0da 100644
+--- a/crypto/blake2s/blake2s.cpp
++++ b/crypto/blake2s/blake2s.cpp
+@@ -245,7 +245,7 @@ static void blake2s_compress(blake2s_state *S, const uint8_t in[BLAKE2S_BLOCKBYT
+ #undef ROUND
+ 
+ 
+-#if defined(ARCH_CPU_X86_FAMILY)
++#if defined(ARCH_CPU_X86_FAMILY) && (defined(__SSE2__) || defined(HAVE_SSSE3) || defined(HAVE_SSE41) || defined(HAVE_AVX) || defined(HAVE_XOP))
+ #include "blake2s-sse-impl.h"
+ #endif
+ 

--- a/tunsafe/patches/0006-add-mipseb-architecture.diff
+++ b/tunsafe/patches/0006-add-mipseb-architecture.diff
@@ -1,0 +1,45 @@
+diff --git a/build_config.h b/build_config.h
+index 81634a5..846ec5c 100644
+--- a/build_config.h
++++ b/build_config.h
+@@ -103,6 +103,11 @@
+ #define ARCH_CPU_MIPSEL 1
+ #define ARCH_CPU_32_BITS 1
+ #define ARCH_CPU_LITTLE_ENDIAN 1
++#elif defined(__MIPSEB__)
++#define ARCH_CPU_MIPS_FAMILY 1
++#define ARCH_CPU_MIPSEB 1
++#define ARCH_CPU_32_BITS 1
++#define ARCH_CPU_LITTLE_ENDIAN 0
+ #elif defined(EMSCRIPTEN)
+ #define ARCH_CPU_JS 1
+ #define ARCH_CPU_32_BITS 1
+diff --git a/tunsafe_cpu.cpp b/tunsafe_cpu.cpp
+index ec14aac..7d4b6fc 100644
+--- a/tunsafe_cpu.cpp
++++ b/tunsafe_cpu.cpp
+@@ -71,9 +71,7 @@ void PrintCpuFeatures() {
+   RINFO("Using:%s", capbuf);
+ }
+ 
+-#endif  // defined(ARCH_CPU_X86_FAMILY)
+-
+-#if defined(ARCH_CPU_ARM_FAMILY)
++#elif defined(ARCH_CPU_ARM_FAMILY)  // defined(ARCH_CPU_X86_FAMILY)
+ 
+ uint32 arm_pcap[1];
+ 
+@@ -88,4 +86,12 @@ void PrintCpuFeatures() {
+ 
+   RINFO("Using:%s", capbuf);
+ }
+-#endif  // defined(ARCH_CPU_ARM_FAMILY)
++#else  // defined(ARCH_CPU_ARM_FAMILY)
++
++void InitCpuFeatures() { }
++
++void PrintCpuFeatures() {
++  RINFO("Using: generic");
++}
++
++#endif  // else


### PR DESCRIPTION
Signed-off-by: Raif Atef <beliskner.github.3psil0N@neverbox.com>

Compile tested: *all arch configs supported by entware*
Run tested: Netgear R7000 ARMv7-2.6 FreshTomato 2020.1

Hello,
I managed to disable ASM and use C fallbacks for other platforms than x86_64 and ARMv7. I also made some patches so that the compile progressively enhances with compile optimize flags that the user may enter. Now it compiles on all archs without any errors.

I hope for merge soon :-)