### PR TITLE
Update run-parts (similar to rc.unslung)

### DIFF
--- a/cron/files/run-parts
+++ b/cron/files/run-parts
@@ -6,13 +6,11 @@
 # based on rc.unslung by unslung guys :-)
 #
 if [ -z "$1" ]; then
-    echo "Usage : $0 "
+    echo "Usage: $0 <dir>"
     exit 0
 fi
 
-RUNDIR=$1"/*"
-
-for i in $RUNDIR ; do
+for i in $(/opt/bin/find $1 -perm '-u+x'); do
 
 # Ignore dangling symlinks (if any).
 [ ! -f "$i" ] && continue


### PR DESCRIPTION
Update run-parts to process only executable scripts

This feed contains unique packages, added by Entware team.

Please double check that your PR is for appropriate feed:
- [rtndev](https://github.com/Entware-for-kernel-3x/rtndev-3x) for packages which was never existed in OpenWrt before.
- [go](https://github.com/Entware-for-kernel-3x/entware-go-3x) for new packages in Golang.
- [oldports](https://github.com/Entware-for-kernel-3x/entware-oldpackages-ports-3x) for packages which is abandoned form OpenWrt for some reason.
- [packages](https://github.com/Entware-for-kernel-3x/entware-packages-3x), [routing](https://github.com/Entware-for-kernel-3x/entware-routing-3x), [telephony](https://github.com/Entware-for-kernel-3x/entware-telephony-3x) for packages, maintained by OpenWrt team.

Please double check that your commits:
- all start with "<package name>: "

Thanks for your contribution
Please remove this text (before ---) and fill the following template
-------------------------------

Compile tested: (put here arch, model, version)
Run tested: (put here arch, model, version, tests done)
