### PR TITLE
Fossil. Updated to 2.24. New iteration

### DIFF
--- a/fossil/Makefile
+++ b/fossil/Makefile
@@ -9,8 +9,8 @@ PKG_VERSION:=2.24
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-src-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://www.fossil-scm.org/home/tarball/66ee0beb9b47d827bde533fe6a1fb2ead4ceb1936468881b4fb621bd6bdfd862
-PKG_HASH:=20c343d10b778f139b8515a4d70cb8b3d5d468c99f1f946468eea9cc7ab32869
+PKG_SOURCE_URL:=https://www.fossil-scm.org/home/tarball/8be0372c1051043761320c8ea8669c3cf320c406e5fe18ad36b7be5f844ca73b
+PKG_HASH:=e6f5a559369bf16baf539e69e6d0cea5a6410efa9a6e7f160c7a4932080413be
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-src-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
New iteration. 

FYI. The tests are:

Test URL for upload archive ( Value is **https://www.fossil-scm.org/home/tarball/8be0372c1051043761320c8ea8669c3cf320c406e5fe18ad36b7be5f844ca73b/fossil-src-2.24.tar.gz** ):
``` sh
-> wget https://www.fossil-scm.org/home/tarball/8be0372c1051043761320c8ea8669c3cf320c406e5fe18ad36b7be5f844ca73b/fossil-src-2.24.tar.gz
--2024-09-15 09:36:15--  https://www.fossil-scm.org/home/tarball/8be0372c1051043761320c8ea8669c3cf320c406e5fe18ad36b7be5f844ca73b/fossil-src-2.24.tar.gz
Resolving www.fossil-scm.org (www.fossil-scm.org)... 45.33.6.223, 2600:3c00::f03c:91ff:fe96:b959
Connecting to www.fossil-scm.org (www.fossil-scm.org)|45.33.6.223|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 6904302 (6,6M) [application/x-compressed]
Saving to: ‘fossil-src-2.24.tar.gz’

fossil-src-2.24.tar.gz     100%[========================================>]   6,58M  1,65MB/s    in 5,4s    

(1,23 MB/s) - ‘fossil-src-2.24.tar.gz’ saved [6904302/6904302]

```

Calculate sha256 (value is **e6f5a559369bf16baf539e69e6d0cea5a6410efa9a6e7f160c7a4932080413be** ):
``` sh
-> sha256sum fossil-src-2.24.tar.gz
e6f5a559369bf16baf539e69e6d0cea5a6410efa9a6e7f160c7a4932080413be  fossil-src-2.24.tar.gz
```

Check fossil version (file VERSION from archive. Value is **2.24**):
``` sh
-> tar -axf fossil-src-2.24.tar.gz fossil-src-2.24/VERSION -O
2.24
```