### PR TITLE
(Need help) Feature: add duperemove package

### DIFF
--- a/duperemove/Makefile
+++ b/duperemove/Makefile
@@ -29,6 +29,7 @@ define Package/duperemove
 	SUBMENU:=Filesystem
 	TITLE:=Duplicate file removal tool
 	URL:=https://github.com/markfasheh/duperemove
+	# This "pkg-config" is reportedly needed by duperemove but it seems to compile fine without it.
 	DEPENDS:= \
 		+libsqlite3 \
 		+glib2 \
@@ -57,47 +58,80 @@ define Package/duperemove/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/btrfs-extent-same $(1)/usr/bin
 endef
 
+# Add "/usr/include" in the include path to have access to "btrfs.h"
+# These headers are not included in the Entware toolchain at $(STAGING_DIR)/opt/include
+TARGET_CFLAGS += \
+	-I/usr/include
+
+# Added these flags to enable linker debugging
+TARGET_CFLAGS += \
+	-Xlinker --verbose
+
+# Adding another path for libintl because the linker wrongly assumes that it's in $(STAGING_DIR)/opt/lib
+TARGET_LDFLAGS += \
+	-L$(STAGING_DIR)/opt/lib/libintl-full/lib
+
+# The linker couldn't also find libiconv, so I added the hacky solution below.
+# I tried using: -L$(STAGING_DIR)/opt/lib/libiconv-full/lib
+# But it didn't work because gcc wouldn't use it during the linking process. 
+# It gets used for linking other shared libraries, but not libiconv.
+#
+# So I tried using "rpath" instead and it seems to work, but I had issues to get a proper path.
+# I noticed that if rpath starts with "/" (e.g. /home/...), then the generated gcc command will treat it as a relative path.
+# If it starts with a non-slash character (e.g. example/opt/lib/...), it'll be treated as an absolute path, which is not what I want.
+# I'm not sure why it's the case. Maybe it's a custom behavior of the compiled gcc from Entware?
+#
+# I previously tried using $ORIGIN in various ways but couldn't find a way to escape it properly.
+# Either the generated gcc command fails because Make doesn't know how to escape it when generating intermediate bash commands, or the final command is incorrect.
+# E.g. Those don't work:
+# -Wl,-rpath,'$$$$ORIGIN'/libiconv-full/lib
+# -Wl,-rpath,"'"'$$'ORIGIN"'"/libiconv-full/lib
+# "'"'$'ORIGIN"'"
+
+# Some dirname magic to get the relative path to the staging directory
+PKG_REL_DIR := \
+	$(shell dirname \
+		$(patsubst \
+			$(shell dirname \
+				$(shell dirname $(PKG_BUILD_DIR)) \
+			)/%,%,$(PKG_BUILD_DIR) \
+		) \
+	)
+TARGET_LDFLAGS += \
+	-Wl,-rpath,/../$(PKG_REL_DIR)/opt/lib/libiconv-full/lib
+
+# DEBUGGING info
+$(info PKG_BUILD_DIR: $(PKG_BUILD_DIR))
+# E.g. PKG_BUILD_DIR: /home/me/Entware/build_dir/target-x86_64_glibc-2.33/duperemove-0.15.1
+$(info TARGET_LDFLAGS = $(TARGET_LDFLAGS))
+# E.g. TARGET_LDFLAGS = -Wl,--dynamic-linker=/opt/lib/ld-linux-x86-64.so.2 -Wl,-rpath=/opt/lib -L/home/me/Entware/staging_dir/toolchain-x86_64_gcc-12.3.0_glibc-2.33/usr/lib -L/home/me/Entware/staging_dir/toolchain-x86_64_gcc-12.3.0_glibc-2.33/lib -fuse-ld=bfd -L/
+
+# I tried other alternatives like copying or creating simlinks to the shared libraries but it felt too hacky. Maybe it's the right way to do it?
 # define Build/Configure
 # $(call Build/Configure/Default,, \
 # 	UNAME_S="Linux" \
 # 	UNAME_R="$(LINUX_VERSION)" \
 # 	UNAME_M="$(ARCH)" \
 # )
-# 	# Copy kernel headers to the staging directory
-# 	$(CP) /usr/include/linux $(STAGING_DIR)/opt/include
-# endef
-
-# define Build/InstallDev
-# 	$(INSTALL_DIR) \
-# 	  $(1)/opt/include \
-# 	  $(1)/opt/lib
-
-# 	$(CP) \
-# 	  $(PKG_INSTALL_DIR)/opt/include/* \
-# 	  $(1)/opt/include/
-
-# 	$(CP) \
-# 	  $(PKG_INSTALL_DIR)/opt/lib/{pkgconfig,*.so*} \
-# 	  $(1)/opt/lib/
-# endef
-
-
-# define Build/Configure
-# $(call Build/Configure/Default,, \
-# 	UNAME_S="Linux" \
-# 	UNAME_R="$(LINUX_VERSION)" \
-# 	UNAME_M="$(ARCH)" \
-# )
-# 	mkdir -p $(PKG_BUILD_DIR)/pppd/plugins/pppoatm/linux
-# 	$(CP) \
-# 		$(LINUX_DIR)/include/linux/compiler.h \
-# 		$(LINUX_DIR)/include/$(LINUX_UAPI_DIR)linux/atm*.h \
-# 		$(PKG_BUILD_DIR)/pppd/plugins/pppoatm/linux/
-
-# 	# Kernel 4.14.9+ only, ignore the exit status of cp in case the file
-# 	# doesn't exits
-# 	-$(CP) $(LINUX_DIR)/include/linux/compiler_types.h \
-# 		$(PKG_BUILD_DIR)/pppd/plugins/pppoatm/linux/
+# 	echo #####################################################	
+# 	echo PKG_BUILD_DIR: $(PKG_BUILD_DIR)
+# 	echo STAGING_DIR: $(STAGING_DIR)
+# 	echo CC: $(CC)
+# 	echo CFLAGS: $(CFLAGS)
+# 	echo EXTRA_CFLAGS: $(EXTRA_CFLAGS)
+# 	echo LDFLAGS: $(LDFLAGS)
+# 	echo TARGET_CFLAGS: $(TARGET_CFLAGS)
+# 	echo TARGET_LDFLAGS: $(TARGET_LDFLAGS)
+# 	echo #####################################################
+#
+# # echo #####################################################
+# # echo # Copy kernel headers to the staging directory
+# # echo #####################################################
+# # $(CP) /usr/include/linux $(STAGING_DIR)/opt/include
+#
+# 	# Create links to some shared libraries
+# 	# I tried using '$ORIGIN' with LDFLAGS but couldn't find a way to escape it properly to please Makefile and the generated gcc command.
+# 	# ln -sf $(STAGING_DIR)/opt/lib/libiconv-full/lib/* $(STAGING_DIR)/opt/lib
 # endef
 
 $(eval $(call BuildPackage,duperemove))

--- a/duperemove/Makefile
+++ b/duperemove/Makefile
@@ -1,0 +1,103 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=duperemove
+PKG_VERSION:=0.15.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/markfasheh/duperemove/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=68cc28f5aa43fa2034e512f7b22cf5282ce2b0319b4e1061f7cdf55cc134273b
+
+PKG_MAINTAINER:=Keith Garner <kgarner@kgarner.com>
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+# Set variables used in the source's Makefile
+export VERSION="$(PKG_VERSION)"
+export IS_RELEASE=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/duperemove
+	SECTION:=utils
+	CATEGORY:=Utilities
+	SUBMENU:=Filesystem
+	TITLE:=Duplicate file removal tool
+	URL:=https://github.com/markfasheh/duperemove
+	DEPENDS:= \
+		+libsqlite3 \
+		+glib2 \
+		+libxxhash \
+		+libuuid \
+		+libmount \
+		+libblkid \
+		+libbsd \
+		+libatomic
+endef
+
+define Package/duperemove/description
+ Duperemove is a simple tool for finding duplicated extents and submitting
+ them for deduplication. When given a list of files it will hash their
+ contents on an extent by extent basis and compare those hashes to each
+ other, finding and categorizing extents that match each other. Optionally,
+ a per-block hash can be applied for further duplication lookup. When given
+ the -d option, duperemove will submit those extents for deduplication using
+ the Linux kernel FIDEDUPRANGE ioctl.
+endef
+
+define Package/duperemove/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/duperemove $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hashstats $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/btrfs-extent-same $(1)/usr/bin
+endef
+
+# define Build/Configure
+# $(call Build/Configure/Default,, \
+# 	UNAME_S="Linux" \
+# 	UNAME_R="$(LINUX_VERSION)" \
+# 	UNAME_M="$(ARCH)" \
+# )
+# 	# Copy kernel headers to the staging directory
+# 	$(CP) /usr/include/linux $(STAGING_DIR)/opt/include
+# endef
+
+# define Build/InstallDev
+# 	$(INSTALL_DIR) \
+# 	  $(1)/opt/include \
+# 	  $(1)/opt/lib
+
+# 	$(CP) \
+# 	  $(PKG_INSTALL_DIR)/opt/include/* \
+# 	  $(1)/opt/include/
+
+# 	$(CP) \
+# 	  $(PKG_INSTALL_DIR)/opt/lib/{pkgconfig,*.so*} \
+# 	  $(1)/opt/lib/
+# endef
+
+
+# define Build/Configure
+# $(call Build/Configure/Default,, \
+# 	UNAME_S="Linux" \
+# 	UNAME_R="$(LINUX_VERSION)" \
+# 	UNAME_M="$(ARCH)" \
+# )
+# 	mkdir -p $(PKG_BUILD_DIR)/pppd/plugins/pppoatm/linux
+# 	$(CP) \
+# 		$(LINUX_DIR)/include/linux/compiler.h \
+# 		$(LINUX_DIR)/include/$(LINUX_UAPI_DIR)linux/atm*.h \
+# 		$(PKG_BUILD_DIR)/pppd/plugins/pppoatm/linux/
+
+# 	# Kernel 4.14.9+ only, ignore the exit status of cp in case the file
+# 	# doesn't exits
+# 	-$(CP) $(LINUX_DIR)/include/linux/compiler_types.h \
+# 		$(PKG_BUILD_DIR)/pppd/plugins/pppoatm/linux/
+# endef
+
+$(eval $(call BuildPackage,duperemove))


### PR DESCRIPTION
-------------------------------

First of all, I'm not a C/C++ developer and my knowledge of GCC + Makefile is very rudimentary so apologies for this incomplete PR. 
I tried to port an [incoming new OpenWRT package named `duperemove`](https://github.com/openwrt/packages/pull/26206) submitted by @ktgeek and wanted to give it a fair go but it's taking more time than I can affort to so I'll just share my code experiments here. 
If anyone qualified wants to pick it up, please be my guest! 😅

## What I've done:

1. Created a docker container based on the wiki docs: https://github.com/Entware/docker/blob/main/README.md
2. Customized the docker image since the original `Dockerfile` hadn't changed in a while.
3. Cloned the entware git repo
4. Copied `configs/x64-3.2.config` to `.config`
5. Ran `make package/symlinks`
6. It seems that the new package I made in `/home/me/Entware/feeds/rtndev/duperemove` didn't get picked up, so I made a symlink myself to `package/feeds/rtndev/duperemove`
7. Compiling `duperemove` fails due to missing `btrfs.h` file. So I tried adding `CONFIG_KERNEL_BTRFS_FS=y` to the `.config`, rebuild the toolchain, but it didn't fix it. I then decided to add an include of `-I/usr/include` to `CFLAGS` in the package `Makefile`.
9. Compiling `duperemove` with the default `Makefile` from https://github.com/openwrt/packages/pull/26206/commits failed. I believe it's related to the introduction of `[[maybe_unused]]` attributes and other syntax errors.
10. Customized the `.config` file to use GCC 12 since the default GCC 8.4 didn't support some code syntax from duperemove. 
11. Enabled `CONFIG_BINUTILS_USE_VERSION_2_34=y` since the Entware toolchain wouldn't build with GCC 12 + glibc v2.27
12. Finally managed to rebuild the toolchain. 
Make command:
```
make dirclean && \
make -j$(nproc) tools/install && \
make -j$(nproc) toolchain/install && \
make -j$(nproc) target/compile && \
make -j1 V=sc package/feeds/rtndev/duperemove/compile |& tee out.txt
```
13. Compiling `duperemove` still fails during the linking phase due to the linker not finding some shared libraries like `libiconv` or `libintl`
14. Customized the `duperemove/Makefile` to expose more include file paths
15. Managed to compile `duperemove` but now it doesn't seem to run properly. 
```
~/Entware/build_dir/target-x86_64_glibc-2.33/duperemove-0.15.1$ ./duperemove 
bash: ./duperemove: No such file or directory

~/Entware/build_dir/target-x86_64_glibc-2.33/duperemove-0.15.1$ cd $(pwd) && readelf -d duperemove

Dynamic section at offset 0x1adf0 contains 27 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libglib-2.0.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libsqlite3.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libblkid.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libmount.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libuuid.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000000f (RPATH)              Library rpath: [/opt/lib:/../target-x86_64_glibc-2.33/opt/lib/libiconv-full/lib]
 0x000000000000000c (INIT)               0x403000
 0x000000000000000d (FINI)               0x413824
 0x0000000000000004 (HASH)               0x4003b0
 0x000000006ffffef5 (GNU_HASH)           0x400728
 0x0000000000000005 (STRTAB)             0x4012d8
 0x0000000000000006 (SYMTAB)             0x400768
 0x000000000000000a (STRSZ)              1612 (bytes)
 0x000000000000000b (SYMENT)             24 (bytes)
 0x0000000000000015 (DEBUG)              0x0
 0x0000000000000003 (PLTGOT)             0x41c000
 0x0000000000000002 (PLTRELSZ)           2736 (bytes)
 0x0000000000000014 (PLTREL)             RELA
 0x0000000000000017 (JMPREL)             0x401bc0
 0x0000000000000007 (RELA)               0x401b18
 0x0000000000000008 (RELASZ)             168 (bytes)
 0x0000000000000009 (RELAENT)            24 (bytes)
 0x000000006ffffffe (VERNEED)            0x401a18
 0x000000006fffffff (VERNEEDNUM)         4
 0x000000006ffffff0 (VERSYM)             0x401924
 0x0000000000000000 (NULL)               0x0
```
I also tried running `duperemove` after installing the generated `duperemove_0.15.1-1_x64-3.2.ipk` package manually on my NAS but the same error appeared.


At this stage, I've spent two days on this but I'm unfortunately forced to let go due to other priorities. 🥲

See this [gist for more info](https://gist.github.com/kayhadrin/ddf3859ebda58754e9f6d5a69c9d1a76):
- my [.config](https://gist.github.com/kayhadrin/ddf3859ebda58754e9f6d5a69c9d1a76#file-config) file and [diff vs the default one.](https://gist.github.com/kayhadrin/ddf3859ebda58754e9f6d5a69c9d1a76#file-diff-x64-3-2-config-config)
- my [Dockerfile](https://gist.github.com/kayhadrin/ddf3859ebda58754e9f6d5a69c9d1a76#file-dockerfile) and [diff vs the latest version.](https://gist.github.com/kayhadrin/ddf3859ebda58754e9f6d5a69c9d1a76#file-dockerfile-vs-90eb6bc0-patch)
- Latest Make [output](https://gist.github.com/kayhadrin/ddf3859ebda58754e9f6d5a69c9d1a76#file-make_output-txt)
- [ELF info about the generated duperemove executable](https://gist.github.com/kayhadrin/ddf3859ebda58754e9f6d5a69c9d1a76#file-readelf-d-duperemove)

Compile tested: intended for x86_64
Run tested: n/a
