### PR TITLE
MegaCMD 2.4.0 - offline build without vcpg

### DIFF
--- a/megacmd/Makefile
+++ b/megacmd/Makefile
@@ -9,8 +9,13 @@ PKG_SOURCE_URL:=https://github.com/meganz/MEGAcmd.git
 PKG_SOURCE_VERSION:=2.4.0_Linux
 PKG_MIRROR_HASH:=skip
 
+PKG_LICENSE:=BSD-2-Clause GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Your Name <your.email@example.com>
+
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=libtool
 
 CMAKE_BINARY_SUBDIR:=.build
 
@@ -22,45 +27,170 @@ define Package/megacmd
 	CATEGORY:=Network
 	SUBMENU:=File Transfer
 	DEPENDS:=+icu +libcares +libcryptopp +libcurl +libmediainfo \
-	+libpcrecpp +libreadline +libsodium +libsqlite3 +libuv \
-	+libopenssl +libffmpeg-full +libfuse +zlib
+		+libpcrecpp +libreadline +libsodium +libsqlite3 +libuv \
+		+libopenssl +libffmpeg-full +libfuse +zlib
 	TITLE:=Command Line Interactive and Scriptable Application
 	URL:=https://github.com/meganz/megacmd
-	MAINTAINER:=Your Name
 endef
 
 define Package/megacmd/description
-	MEGAcmd provides non UI access to MEGA services.
-	This package builds version 2.x using CMake without vcpkg.
+	MEGAcmd provides non-UI access to MEGA services. It features a
+	server-client architecture where the server handles all cloud
+	operations and multiple clients can send commands to it.
+
+	This package includes command-line tools for file transfer,
+	synchronization, and cloud storage management.
+
+	License: BSD-2-Clause AND GPL-3.0-or-later
+	See /opt/share/doc/megacmd/LICENSE for full license text.
 endef
 
-# Disable vcpkg and provide cryptopp paths
+# Check if tests are enabled via environment variable
+# Usage: make package/feeds/rtndev/megacmd/compile MEGACMD_ENABLE_TESTS=1
+ifeq ($(MEGACMD_ENABLE_TESTS),1)
+CMAKE_OPTIONS += \
+	-DENABLE_MEGACMD_TESTS=ON \
+	-DFETCHCONTENT_FULLY_DISCONNECTED=OFF \
+	-DFETCHCONTENT_QUIET=OFF
+else
+# Default: disable tests for production builds
+CMAKE_OPTIONS += \
+	-DENABLE_MEGACMD_TESTS=OFF
+endif
+
+# Disable vcpkg and external package managers
 CMAKE_OPTIONS += \
 	-DUSE_VCPKG=OFF \
 	-DENABLE_VCPKG=OFF \
 	-DCMAKE_DISABLE_FIND_PACKAGE_Vcpkg=ON \
-	-DFULL_REQS=OFF \
+	-DFULL_REQS=OFF
+
+# Feature selection
+CMAKE_OPTIONS += \
 	-DUSE_PDFIUM=OFF \
 	-DUSE_FREEIMAGE=OFF \
 	-DUSE_FFMPEG=ON \
+	-DUSE_PCRE=ON \
+	-DENABLE_MEDIA_FILE_METADATA=ON \
+	-DUSE_READLINE=ON \
+	-DUSE_LIBUV=ON \
+	-DUSE_OPENSSL=ON
+
+# Library paths for Entware staging
+CMAKE_OPTIONS += \
 	-DFUSE_INCLUDE_DIR=$(STAGING_DIR)/opt/include/fuse \
 	-DFUSE_LIBRARY=$(STAGING_DIR)/opt/lib/libfuse.so \
 	-DCRYPTOPP_INCLUDE_DIR=$(STAGING_DIR)/opt/include \
-	-DCRYPTOPP_LIBRARY=$(STAGING_DIR)/opt/lib/libcryptopp.so \
+	-DCRYPTOPP_LIBRARY=$(STAGING_DIR)/opt/lib/libcryptopp.so
+
+# Installation configuration
+CMAKE_OPTIONS += \
 	-DCMAKE_INSTALL_PREFIX=/opt \
 	-DCMAKE_INSTALL_BINDIR=bin \
 	-DCMAKE_INSTALL_LIBDIR=lib \
 	-DBUILD_SHARED_LIBS=ON
 
+define Package/megacmd/conffiles
+/opt/etc/sysctl.d/99-megacmd-inotify-limit.conf
+endef
+
+# Custom test hook - runs after Build/Compile if tests are enabled
+define Build/RunTests
+	echo ""; \
+	echo "========================================"; \
+	echo "Running MEGAcmd Tests"; \
+	echo "========================================"; \
+	echo ""; \
+	echo "Note: Tests require Google Test which will be downloaded during build"; \
+	echo ""; \
+	cd $(PKG_BUILD_DIR)/$(CMAKE_BINARY_SUBDIR) && \
+	export MEGACMD_TEST_USER=$(MEGACMD_TEST_USER) MEGACMD_TEST_PASS=$(MEGACMD_TEST_PASS) && export LD_LIBRARY_PATH=$(PKG_BUILD_DIR)/$(CMAKE_BINARY_SUBDIR)/sdk:$(PKG_BUILD_DIR)/$(CMAKE_BINARY_SUBDIR)/lib:$(STAGING_DIR)/opt/lib:$(TOOLCHAIN_DIR)/lib:$$$$$$$$LD_LIBRARY_PATH && \
+	if [ -f mega-cmd-tests-unit ]; then \
+		echo "Running unit tests..."; \
+		if [ -x "$(TOOLCHAIN_DIR)/lib/ld-linux-x86-64.so.2" ]; then \
+			$(TOOLCHAIN_DIR)/lib/ld-linux-x86-64.so.2 ./mega-cmd-tests-unit --gtest_brief=1 || { echo "Unit tests failed!"; exit 1; }; \
+		else \
+			./mega-cmd-tests-unit --gtest_brief=1 || { echo "Unit tests failed!"; exit 1; }; \
+		fi; \
+		echo ""; \
+	else \
+		echo "Warning: Unit test binary not found"; \
+	fi; \
+	if [ -f mega-cmd-tests-integration ]; then \
+		echo "Running integration tests..."; \
+		echo "Note: Integration tests may require network access and MEGA credentials"; \
+		if [ -x "$(TOOLCHAIN_DIR)/lib/ld-linux-x86-64.so.2" ]; then \
+			$(TOOLCHAIN_DIR)/lib/ld-linux-x86-64.so.2 ./mega-cmd-tests-integration --gtest_brief=1 || { echo "Integration tests failed (may be expected without credentials)"; }; \
+		else \
+			./mega-cmd-tests-integration --gtest_brief=1 || { echo "Integration tests failed (may be expected without credentials)"; }; \
+		fi; \
+		echo ""; \
+	else \
+		echo "Warning: Integration test binary not found"; \
+	fi; \
+	echo "========================================"; \
+	echo "Test execution completed"; \
+	echo "========================================"; \
+	echo "";
+endef
+
+# Hook the test execution after compilation
+ifeq ($(MEGACMD_ENABLE_TESTS),1)
+  Hooks/Compile/Post += Build/RunTests
+endif
+
 define Package/megacmd/install
+	# Install binaries
 	$(INSTALL_DIR) $(1)/opt/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/opt/bin/mega-* $(1)/opt/bin/
+	rm -f $(1)/opt/bin/mega-cmd-tests-*
+
+	# Install shared library
 	$(INSTALL_DIR) $(1)/opt/lib
 	$(CP) $(PKG_INSTALL_DIR)/opt/lib/libmega.so* $(1)/opt/lib/
+	$(CP) $(PKG_INSTALL_DIR)/opt/lib/libg{test,mock}*.so* $(1)/opt/lib/
+
+	# Install bash completion
 	$(INSTALL_DIR) $(1)/opt/etc/bash_completion.d
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/opt/etc/bash_completion.d/megacmd_completion.sh $(1)/opt/etc/bash_completion.d/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/opt/etc/bash_completion.d/megacmd_completion.sh \
+		$(1)/opt/etc/bash_completion.d/
+
+	# Install sysctl configuration for inotify limits
 	$(INSTALL_DIR) $(1)/opt/etc/sysctl.d
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/opt/etc/sysctl.d/99-megacmd-inotify-limit.conf $(1)/opt/etc/sysctl.d/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/opt/etc/sysctl.d/99-megacmd-inotify-limit.conf \
+		$(1)/opt/etc/sysctl.d/
+
+	# Install license documentation (BSD-2-Clause compliance)
+	$(INSTALL_DIR) $(1)/opt/share/doc/megacmd
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/LICENSE $(1)/opt/share/doc/megacmd/
+
+	# Install README if present
+	[ ! -f $(PKG_BUILD_DIR)/README.md ] || \
+		$(INSTALL_DATA) $(PKG_BUILD_DIR)/README.md $(1)/opt/share/doc/megacmd/
+endef
+
+define Package/megacmd/postinst
+#!/bin/sh
+# Apply sysctl settings if system supports it
+if [ -f /opt/etc/sysctl.d/99-megacmd-inotify-limit.conf ] && [ -x /opt/sbin/sysctl ]; then
+	/opt/sbin/sysctl -p /opt/etc/sysctl.d/99-megacmd-inotify-limit.conf 2>/dev/null || true
+fi
+
+echo ""
+echo "MEGAcmd installed successfully."
+echo "Run 'mega-help' to get started or 'mega-cmd-server' to start the server."
+echo ""
+echo "License: BSD-2-Clause AND GPL-3.0-or-later"
+echo "See /opt/share/doc/megacmd/LICENSE for full license text."
+echo ""
+exit 0
+endef
+
+define Package/megacmd/prerm
+#!/bin/sh
+# Kill running mega-cmd-server instances
+killall mega-cmd-server 2>/dev/null || true
+exit 0
 endef
 
 $(eval $(call BuildPackage,megacmd))

--- a/megacmd/Makefile
+++ b/megacmd/Makefile
@@ -1,54 +1,66 @@
-# SPDX-License-Identifier: GPL-2.0-only
-#
-# Copyright (C) 2011-2025 Entware
-#
-# The newer versions based on cmake+vcpkg build system with online dependencies installation
-
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=megacmd
-PKG_VERSION:=1.7.0
-PKG_REV:=bc0e4016eeb561677e8078294422e9b1619515b5
+PKG_VERSION:=2.4.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://github.com/meganz/MEGAcmd.git
 PKG_SOURCE_PROTO:=git
-PKG_MIRROR_HASH:=8b47296930c42a61ade9ca6e5e06ce26e9e6189a6d604c1292c2d299f26e6911
+PKG_SOURCE_URL:=https://github.com/meganz/MEGAcmd.git
+PKG_SOURCE_VERSION:=2.4.0_Linux
+PKG_MIRROR_HASH:=skip
 
-PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+CMAKE_BINARY_SUBDIR:=.build
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/megacmd
 	SECTION:=net
 	CATEGORY:=Network
 	SUBMENU:=File Transfer
 	DEPENDS:=+icu +libcares +libcryptopp +libcurl +libmediainfo \
-	    +libpcre +libreadline +libsodium +libsqlite3 +libuv
+	+libpcrecpp +libreadline +libsodium +libsqlite3 +libuv \
+	+libopenssl +libffmpeg-full +libfuse +zlib
 	TITLE:=Command Line Interactive and Scriptable Application
 	URL:=https://github.com/meganz/megacmd
-	MAINTAINER:=Entware team, https://entware.net
+	MAINTAINER:=Your Name
 endef
 
 define Package/megacmd/description
- MEGAcmd provides non UI access to MEGA services. It intends to offer all the
- functionality with your MEGA account via commands.
+	MEGAcmd provides non UI access to MEGA services.
+	This package builds version 2.x using CMake without vcpkg.
 endef
 
-CONFIGURE_ARGS += \
-    --disable-doxygen-doc \
-    --without-freeimage \
-    --without-ffmpeg
+# Disable vcpkg and provide cryptopp paths
+CMAKE_OPTIONS += \
+	-DUSE_VCPKG=OFF \
+	-DENABLE_VCPKG=OFF \
+	-DCMAKE_DISABLE_FIND_PACKAGE_Vcpkg=ON \
+	-DFULL_REQS=OFF \
+	-DUSE_PDFIUM=OFF \
+	-DUSE_FREEIMAGE=OFF \
+	-DUSE_FFMPEG=ON \
+	-DFUSE_INCLUDE_DIR=$(STAGING_DIR)/opt/include/fuse \
+	-DFUSE_LIBRARY=$(STAGING_DIR)/opt/lib/libfuse.so \
+	-DCRYPTOPP_INCLUDE_DIR=$(STAGING_DIR)/opt/include \
+	-DCRYPTOPP_LIBRARY=$(STAGING_DIR)/opt/lib/libcryptopp.so \
+	-DCMAKE_INSTALL_PREFIX=/opt \
+	-DCMAKE_INSTALL_BINDIR=bin \
+	-DCMAKE_INSTALL_LIBDIR=lib \
+	-DBUILD_SHARED_LIBS=ON
 
 define Package/megacmd/install
 	$(INSTALL_DIR) $(1)/opt/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/opt/bin/mega-* $(1)/opt/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/opt/bin/mega-* $(1)/opt/bin/
 	$(INSTALL_DIR) $(1)/opt/lib
-	$(CP) $(PKG_INSTALL_DIR)/opt/lib/libmega.so* $(1)/opt/lib
-	$(SED) 's,^#!.*bash,#!/opt/bin/sh,' $(1)/opt/bin/*
+	$(CP) $(PKG_INSTALL_DIR)/opt/lib/libmega.so* $(1)/opt/lib/
+	$(INSTALL_DIR) $(1)/opt/etc/bash_completion.d
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/opt/etc/bash_completion.d/megacmd_completion.sh $(1)/opt/etc/bash_completion.d/
+	$(INSTALL_DIR) $(1)/opt/etc/sysctl.d
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/opt/etc/sysctl.d/99-megacmd-inotify-limit.conf $(1)/opt/etc/sysctl.d/
 endef
 
 $(eval $(call BuildPackage,megacmd))

--- a/megacmd/patches/001-fix-cryptopp-path.patch
+++ b/megacmd/patches/001-fix-cryptopp-path.patch
@@ -1,0 +1,19 @@
+--- a/sdk/cmake/modules/sdklib_libraries.cmake
++++ b/sdk/cmake/modules/sdklib_libraries.cmake
+@@ -49,8 +49,14 @@ macro(load_sdklib_libraries)
+ 
+         find_package(PkgConfig REQUIRED) # For libraries loaded using pkg-config
+ 
+-        pkg_check_modules(cryptopp REQUIRED IMPORTED_TARGET libcrypto++)
+-        target_link_libraries(SDKlib PUBLIC PkgConfig::cryptopp) # TODO: Private for SDK core
++        if(CRYPTOPP_LIBRARY)
++            include_directories(${CRYPTOPP_INCLUDE_DIR})
++            target_link_libraries(SDKlib PUBLIC ${CRYPTOPP_LIBRARY})
++            message(STATUS "Using provided CRYPTOPP_LIBRARY: ${CRYPTOPP_LIBRARY}")
++        else()
++            pkg_check_modules(cryptopp REQUIRED IMPORTED_TARGET libcrypto++)
++            target_link_libraries(SDKlib PUBLIC PkgConfig::cryptopp) # TODO: Private for SDK core
++        endif()
+ 
+         pkg_check_modules(sodium REQUIRED IMPORTED_TARGET libsodium)
+         target_link_libraries(SDKlib PRIVATE PkgConfig::sodium)

--- a/megacmd/patches/002-cryptopp.patch
+++ b/megacmd/patches/002-cryptopp.patch
@@ -1,0 +1,29 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -23,7 +23,7 @@
+ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/build/cmake/modules) # Modules from MEGAcmd
+ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/sdk/cmake/modules) # Modules from MEGAsdk
+
+-set(VCPKG_ROOT "${CMAKE_CURRENT_LIST_DIR}/../vcpkg" CACHE PATH "If set, it will build and use the VCPKG packages defined in the manifest file")
++set(VCPKG_ROOT "" CACHE PATH "Disabled in Entware build")
+
+ include(detect_host_architecture)
+
+@@ -44,7 +44,7 @@
+ )
+ endif()
+
+-if((NOT WIN32 OR BASH_VERSION_RESULT EQUAL 0) AND NOT EXISTS ${VCPKG_ROOT})
++if(FALSE)
+     message(STATUS "vcpkg will be cloned into ${VCPKG_ROOT}")
+     execute_process(
+         #TODO: have the same for windows ... or at least check if bash is available
+@@ -82,7 +82,7 @@
+ message(STATUS "Using VCPKG_ROOT = ${VCPKG_ROOT}")
+
+-if(VCPKG_ROOT)
++if(FALSE)
+     if (ENABLE_MEGACMD_TESTS)
+         list(APPEND VCPKG_MANIFEST_FEATURES "megacmd-enable-tests")
+     endif()
+

--- a/megacmd/patches/003-fix-cloudraid-pimpl.patch
+++ b/megacmd/patches/003-fix-cloudraid-pimpl.patch
@@ -1,0 +1,11 @@
+--- a/sdk/include/mega/raid.h
++++ b/sdk/include/mega/raid.h
+@@ -281,7 +281,7 @@
+         const CloudRaidImpl* mPimpl() const { return m_pImpl.get(); }
+         CloudRaidImpl* mPimpl() { return m_pImpl.get(); }
+ 
+-        std::unique_ptr<CloudRaidImpl> m_pImpl{};
++        std::unique_ptr<CloudRaidImpl> m_pImpl;
+         bool mShown{};
+ 
+     public:

--- a/megacmd/patches/004-fix-hashcash.patch
+++ b/megacmd/patches/004-fix-hashcash.patch
@@ -1,0 +1,20 @@
+--- a/sdk/src/hashcash.cpp
++++ b/sdk/src/hashcash.cpp
+@@ -82,7 +82,7 @@
+     h.Update(data, static_cast<unsigned>(len));
+ 
+     uint32_t word{};
+-    h.TruncatedFinal(reinterpret_cast<CryptoPP::byte*>(&word), 4);
++    h.TruncatedFinal(reinterpret_cast<unsigned char*>(&word), 4);
+     return word;
+ }
+ 
+@@ -220,7 +220,7 @@
+         }
+ 
+         uint32_t firstWord{};
+-        hasher.TruncatedFinal(reinterpret_cast<CryptoPP::byte*>(&firstWord), sizeof(uint32_t));
++        hasher.TruncatedFinal(reinterpret_cast<unsigned char*>(&firstWord), sizeof(uint32_t));
+ 
+         if (htonl(firstWord) <= thresholdNetOrder)
+         {

--- a/megacmd/patches/005-fix-sqlite-transform-reduce.patch
+++ b/megacmd/patches/005-fix-sqlite-transform-reduce.patch
@@ -1,0 +1,27 @@
+--- a/sdk/src/db/sqlite.cpp
++++ b/sdk/src/db/sqlite.cpp
+@@ -535,16 +535,15 @@
+ 
+         std::vector<std::unique_ptr<MigrateType>> migrateElement;
+         migrateElement.reserve(cols.size());
+-        bool hasValues = std::transform_reduce(
+-            cols.begin(),
+-            cols.end(),
+-            false,
+-            std::logical_or{},
+-            [&migrateElement, &nd](const NewColumn& c) -> bool
++        bool hasValues = false;
++        for (const auto& c : cols)
++        {
++            assert(c.migrateOperation);
++            if (c.migrateOperation(nd, migrateElement))
+             {
+-                assert(c.migrateOperation);
+-                return c.migrateOperation(nd, migrateElement);
+-            });
++                hasValues = true;
++            }
++        }
+ 
+ 
+         ++numRows;

--- a/megacmd/patches/006-fix-serialization-traits.patch
+++ b/megacmd/patches/006-fix-serialization-traits.patch
@@ -1,0 +1,71 @@
+--- a/sdk/include/mega/common/serialization_traits_forward.h
++++ b/sdk/include/mega/common/serialization_traits_forward.h
+@@ -7,10 +7,6 @@
+ template<typename T>
+ struct HasSerializationTraits;
+ 
+-template<typename T>
+-static constexpr auto HasSerializationTraitsV =
+-  HasSerializationTraits<T>::value;
+-
+ template<typename T>
+ struct SerializationTraits;
+ 
+--- a/sdk/include/mega/common/serialization_traits.h
++++ b/sdk/include/mega/common/serialization_traits.h
+@@ -14,5 +14,9 @@
+ {
+ }; // HasSerializationTraits<T>
+ 
++template<typename T>
++constexpr bool HasSerializationTraitsV =
++  HasSerializationTraits<T>::value;
++
+ } // common
+ } // mega
+--- a/sdk/include/mega/common/expected_forward.h
++++ b/sdk/include/mega/common/expected_forward.h
+@@ -17,7 +17,4 @@
+ template<typename T>
+ struct IsExpected;
+ 
+-template<typename T>
+-constexpr auto IsExpectedV = IsExpected<T>::value;
+-
+ } // common
+--- a/sdk/include/mega/common/expected.h
++++ b/sdk/include/mega/common/expected.h
+@@ -31,6 +31,9 @@
+ struct IsExpected: detail::IsExpected<std::decay_t<T>>
+ {};
+ 
++template<typename T>
++constexpr bool IsExpectedV = IsExpected<T>::value;
++
+ template<typename E, typename T>
+ class Expected
+ {
+--- a/sdk/include/mega/common/unexpected_forward.h
++++ b/sdk/include/mega/common/unexpected_forward.h
+@@ -15,9 +17,6 @@
+ template<typename T>
+ class Unexpected;
+ 
+-template<typename T>
+-constexpr auto IsUnexpectedV = IsUnexpected<T>::value;
+-
+ template<typename T>
+ auto unexpected(T&& value);
+ 
+--- a/sdk/include/mega/common/unexpected.h
++++ b/sdk/include/mega/common/unexpected.h
+@@ -24,6 +24,9 @@
+ struct IsUnexpected: detail::IsUnexpected<std::decay_t<T>>
+ {};
+ 
++template<typename T>
++constexpr bool IsUnexpectedV = IsUnexpected<T>::value;
++
+ template<typename T>
+ class Unexpected
+ {

--- a/megacmd/patches/007-fix-statx-glibc-2.27.patch
+++ b/megacmd/patches/007-fix-statx-glibc-2.27.patch
@@ -1,0 +1,28 @@
+--- a/sdk/src/fuse/supported/platform/posix/linux/utility.cpp.orig	2026-02-09 09:48:35.533895629 +0000
++++ b/sdk/src/fuse/supported/platform/posix/linux/utility.cpp	2026-02-09 09:48:35.563895239 +0000
+@@ -24,14 +24,11 @@
+ bool abort(const std::string& path)
+ {
+     // Clarity.
+-    constexpr auto flags = AT_STATX_DONT_SYNC;
+-    constexpr auto mask = STATX_BASIC_STATS;
+ 
+-    // Try and retrieve information about path.
+-    struct statx attributes;
++    struct stat attributes;
+ 
+     // Couldn't retrieve information about path.
+-    if (statx(0, path.c_str(), flags, mask, &attributes))
++    if (stat(path.c_str(), &attributes))
+     {
+         FUSEErrorF("Couldn't retrieve information about %s: %s",
+                    path.c_str(),
+@@ -41,7 +38,7 @@
+     }
+ 
+     // Compute absolute device number.
+-    auto device = makedev(attributes.stx_dev_major, attributes.stx_dev_minor);
++    auto device = attributes.st_dev;
+ 
+     // Compute abort file path.
+     auto abortPath = format("/sys/fs/fuse/connections/%lu/abort", device);

--- a/megacmd/patches/008-fix-linking-pcrecpp-zlib.patch
+++ b/megacmd/patches/008-fix-linking-pcrecpp-zlib.patch
@@ -1,0 +1,23 @@
+--- a/build/cmake/modules/megacmd_libraries.cmake
++++ b/build/cmake/modules/megacmd_libraries.cmake
+@@ -15,11 +15,17 @@
+     else() # No VCPKG usage. Use pkg-config
+         find_package(PkgConfig REQUIRED) # For libraries loaded using pkg-config
+ 
+-        if(USE_PCRE) #TODO: UNTESTED!
+-            pkg_check_modules(pcre REQUIRED IMPORTED_TARGET libpcre)
+-            target_link_libraries(LMegacmdServer PRIVATE PkgConfig::pcre)
++        if(USE_PCRE)
++            pkg_check_modules(pcrecpp REQUIRED IMPORTED_TARGET libpcrecpp)
++            target_link_libraries(LMegacmdServer PUBLIC PkgConfig::pcrecpp)
+             set(USE_PCRE 1)
+         endif()
++
++        pkg_check_modules(readline REQUIRED IMPORTED_TARGET readline)
++        target_link_libraries(LMegacmdServer PUBLIC PkgConfig::readline)
++
++        find_package(ZLIB REQUIRED)
++        target_link_libraries(LMegacmdServer PUBLIC ZLIB::ZLIB)
+     endif()
+ 
+ endmacro()

--- a/megacmd/patches/009-fix-install-paths.patch
+++ b/megacmd/patches/009-fix-install-paths.patch
@@ -1,0 +1,32 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -134,8 +134,6 @@
+     # If CMAKE_INSTALL_PREFIX is not set, it will set rpath to /opt/....
+     # Note: using cmake --install --prefix /some/prefix will not set rpath relative to that prefix
+     # The above can be used for building packages: in which install dir is a path construction folder that will not be there in packages
+-    set(CMAKE_INSTALL_LIBDIR "opt/megacmd/lib")
+-    set(CMAKE_INSTALL_BINDIR "usr/bin") #override default "bin"
+ 
+     if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+         message(STATUS "Overriding default CMAKE_INSTALL_PREFIX to /")
+@@ -475,11 +473,13 @@
+     else()
+         SET(vcpkg_lib_folder "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/")
+     endif()
+-    install(DIRECTORY "${vcpkg_lib_folder}"
+-            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-            FILES_MATCHING
+-            PATTERN "lib*.so*"
+-            PATTERN "*dylib*" #macOS
+-            PATTERN "manual-link" EXCLUDE
+-            PATTERN "pkgconfig" EXCLUDE)
++    if(VCPKG_INSTALLED_DIR AND VCPKG_TARGET_TRIPLET)
++        install(DIRECTORY "${vcpkg_lib_folder}"
++                DESTINATION ${CMAKE_INSTALL_LIBDIR}
++                FILES_MATCHING
++                PATTERN "lib*.so*"
++                PATTERN "*dylib*" #macOS
++                PATTERN "manual-link" EXCLUDE
++                PATTERN "pkgconfig" EXCLUDE)
++    endif()
+ endif() #not WIN32

--- a/megacmd/patches/010-set-sdklib-output-name.patch
+++ b/megacmd/patches/010-set-sdklib-output-name.patch
@@ -1,0 +1,10 @@
+--- a/sdk/cmake/modules/sdklib_target.cmake
++++ b/sdk/cmake/modules/sdklib_target.cmake
+@@ -382,6 +382,7 @@
+ set_target_properties(SDKlib PROPERTIES
+     VERSION ${PROJECT_VERSION}
+     DEBUG_POSTFIX "d"
++    OUTPUT_NAME "mega"
+ )
+ 
+ if(ENABLE_JAVA_BINDINGS)

--- a/megacmd/patches/011-ccronexpr-fpic.patch
+++ b/megacmd/patches/011-ccronexpr-fpic.patch
@@ -1,0 +1,12 @@
+--- a/sdk/third_party/ccronexpr/CMakeLists.txt
++++ b/sdk/third_party/ccronexpr/CMakeLists.txt
+@@ -8,8 +8,4 @@ target_include_directories(ccronexpr SYS
+     ${CMAKE_CURRENT_SOURCE_DIR}
+ )
+ 
+-if(ENABLE_JAVA_BINDINGS)
+-    set_target_properties(ccronexpr PROPERTIES
+-        POSITION_INDEPENDENT_CODE ON
+-    )
+-endif()
++set_target_properties(ccronexpr PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/megacmd/patches/012-sdklib-public-deps.patch
+++ b/megacmd/patches/012-sdklib-public-deps.patch
@@ -1,0 +1,72 @@
+--- a/sdk/cmake/modules/sdklib_libraries.cmake
++++ b/sdk/cmake/modules/sdklib_libraries.cmake
+@@ -98,33 +98,36 @@
+         endif()
+ 
+         pkg_check_modules(sodium REQUIRED IMPORTED_TARGET libsodium)
+-        target_link_libraries(SDKlib PRIVATE PkgConfig::sodium)
++        target_link_libraries(SDKlib PUBLIC PkgConfig::sodium)
+ 
+         pkg_check_modules(sqlite3 REQUIRED IMPORTED_TARGET sqlite3)
+-        target_link_libraries(SDKlib PRIVATE PkgConfig::sqlite3)
++        target_link_libraries(SDKlib PUBLIC PkgConfig::sqlite3)
+ 
+         pkg_check_modules(curl REQUIRED IMPORTED_TARGET libcurl)
+-        target_link_libraries(SDKlib PRIVATE PkgConfig::curl)
++        target_link_libraries(SDKlib PUBLIC PkgConfig::curl)
+ 
+         find_package(ICU COMPONENTS uc data REQUIRED)
+-        target_link_libraries(SDKlib PRIVATE ICU::uc ICU::data)
++        target_link_libraries(SDKlib PUBLIC ICU::uc ICU::data)
+ 
+         if(USE_OPENSSL)
+             find_package(OpenSSL REQUIRED)
+-            target_link_libraries(SDKlib PRIVATE OpenSSL::SSL OpenSSL::Crypto)
++            target_link_libraries(SDKlib PUBLIC OpenSSL::SSL OpenSSL::Crypto)
+         endif()
+ 
++        find_package(Threads REQUIRED)
++        target_link_libraries(SDKlib PUBLIC Threads::Threads)
++
+         if(ENABLE_MEDIA_FILE_METADATA)
+             pkg_check_modules(mediainfo REQUIRED IMPORTED_TARGET libmediainfo)
+-            target_link_libraries(SDKlib PRIVATE PkgConfig::mediainfo)
++            target_link_libraries(SDKlib PUBLIC PkgConfig::mediainfo)
+             set(USE_MEDIAINFO 1)
+         endif()
+ 
+         if(USE_FREEIMAGE)
+             # FreeImage has no pkg-config file. Use out own FindFreeImage.cmake to find the library.
+             find_package(FreeImage REQUIRED)
+-            target_link_libraries(SDKlib PRIVATE FreeImage::FreeImage)
++            target_link_libraries(SDKlib PUBLIC FreeImage::FreeImage)
+         endif()
+ 
+         if(USE_FFMPEG)
+             pkg_check_modules(ffmpeg REQUIRED IMPORTED_TARGET libavformat libavutil libavcodec libswscale libswresample)
+-            target_link_libraries(SDKlib PRIVATE PkgConfig::ffmpeg)
++            target_link_libraries(SDKlib PUBLIC PkgConfig::ffmpeg)
+             set(HAVE_FFMPEG 1)
+         endif()
+ 
+         if(USE_LIBUV)
+             pkg_check_modules(uv REQUIRED IMPORTED_TARGET libuv)
+-            target_link_libraries(SDKlib PRIVATE PkgConfig::uv)
++            target_link_libraries(SDKlib PUBLIC PkgConfig::uv)
+             set(HAVE_LIBUV 1)
+         endif()
+ 
+         if(USE_PDFIUM)
+             pkg_check_modules(pdfium REQUIRED IMPORTED_TARGET pdfium)
+-            target_link_libraries(SDKlib PRIVATE PkgConfig::pdfium)
++            target_link_libraries(SDKlib PUBLIC PkgConfig::pdfium)
+             set(HAVE_PDFIUM 1)
+         endif()
+ 
+         if(USE_READLINE)
+             pkg_check_modules(readline REQUIRED IMPORTED_TARGET readline)
+-            target_link_libraries(SDKlib PRIVATE PkgConfig::readline)
++            target_link_libraries(SDKlib PUBLIC PkgConfig::readline)
+         else()
+             set(NO_READLINE 1)
+         endif()

--- a/megacmd/patches/013-fix-executables-linking.patch
+++ b/megacmd/patches/013-fix-executables-linking.patch
@@ -1,0 +1,35 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -215,6 +215,10 @@
+     "${ProjectDir}/src/megacmdplatform.mm"
+ )
+ 
++# Load 3rd parties
++load_megacmdserver_libraries()
++
++
+ # Given we are no longer including the sdk, and some sources use certain defines without including SDK's config.h,
+ # We need to explicitly pass the compiling options.
+ target_compile_definitions(LMegacmdServer
+@@ -381,9 +385,9 @@
+ endif()
+ 
+ target_link_libraries(LMegacmdClient PUBLIC MEGA::SDKlib LMEGAcmdCommonUtils)
+-target_link_libraries(mega-exec LMegacmdClient)
+-target_link_libraries(mega-cmd PUBLIC MEGA::SDKlib LMEGAcmdCommonUtils)
+-target_link_libraries(mega-cmd-updater PUBLIC MEGA::SDKlib LMEGAcmdCommonUtils)
++target_link_libraries(mega-exec LMegacmdClient PkgConfig::pcrecpp ZLIB::ZLIB)
++target_link_libraries(mega-cmd PUBLIC MEGA::SDKlib LMEGAcmdCommonUtils PkgConfig::pcrecpp ZLIB::ZLIB PkgConfig::readline)
++target_link_libraries(mega-cmd-updater PUBLIC MEGA::SDKlib LMEGAcmdCommonUtils PkgConfig::pcrecpp ZLIB::ZLIB)
+ target_link_libraries(LMegacmdServer PUBLIC MEGA::SDKlib LMEGAcmdCommonUtils)
+ 
+ if (ENABLE_MEGACMD_TESTS)
+@@ -401,8 +405,6 @@
+     target_link_libraries(mega-cmd-tests-unit PUBLIC LMegacmdServer LMegacmdTestsCommon)
+ endif()
+ 
+-# Load 3rd parties #TODO: consider splitting by target?
+-load_megacmdserver_libraries()
+ 
+ #file(GET_RUNTIME_DEPENDENCIES ... _deps)
+ #foreach(_dep IN LISTS _deps)

--- a/megacmd/patches/014-install-sdklib.patch
+++ b/megacmd/patches/014-install-sdklib.patch
@@ -1,0 +1,12 @@
+--- a/sdk/cmake/modules/sdklib_target.cmake
++++ b/sdk/cmake/modules/sdklib_target.cmake
+@@ -500,3 +500,9 @@ configure_file(
+     cmake/modules/sdklib.pc.in
+     ${CMAKE_CURRENT_BINARY_DIR}/sdklib.pc @ONLY
+     )
++
++install(TARGETS SDKlib
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++)

--- a/megacmd/patches/015-add-gtest-support.patch
+++ b/megacmd/patches/015-add-gtest-support.patch
@@ -1,0 +1,29 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -325,10 +325,25 @@
+     "${ProjectDir}/src/updater/MacUtils.mm"
+ )
+ 
+-if (ENABLE_MEGACMD_TESTS)
++if (ENABLE_MEGACMD_TESTS)
++    # For Entware/OpenWrt builds, fetch googletest if not available
++    # This allows tests to build without requiring system-wide gtest installation
++    if(NOT TARGET gtest)
++        include(FetchContent)
++        FetchContent_Declare(
++            googletest
++            URL https://github.com/google/googletest/archive/release-1.12.1.tar.gz
++            URL_HASH SHA256=81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2
++        )
++        # Force shared CRT on Windows
++        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
++        FetchContent_MakeAvailable(googletest)
++    endif()
++
+     #Test Common:
+     add_library(LMegacmdTestsCommon STATIC)
++    target_link_libraries(LMegacmdTestsCommon PUBLIC gtest gmock)
+     add_source_and_corresponding_header_to_target(LMegacmdTestsCommon PRIVATE
+         "${ProjectDir}/tests/common/Instruments.cpp"
+         "${ProjectDir}/tests/common/TestUtils.cpp"
+     )

--- a/megacmd/patches/016-fix-gcc8-ice.patch
+++ b/megacmd/patches/016-fix-gcc8-ice.patch
@@ -1,0 +1,11 @@
+--- a/src/comunicationsmanager.h
++++ b/src/comunicationsmanager.h
+@@ -47,7 +47,7 @@
+ 
+     mega::MegaThread *getPetitionThread() const;
+     void setPetitionThread(mega::MegaThread *value);
+-    virtual std::string getPetitionDetails() const { return {}; }
++    virtual std::string getPetitionDetails() const { return std::string(); }
+ };
+ 
+ class ComunicationsManager


### PR DESCRIPTION
Draft PR for now just to get some early feedback.

Compile tested: (x86_64)
Run tested: (x86_64, DS920+, 7.2.2-72806 Update 3, logged in with 2FA, tested sync to my MEGA, tested mega-ls, mega-session, mega-logout - all working)

requires installing via:
sudo opkg install libpcrecpp_8.45-5_x64-3.2.ipk
sudo opkg install megacmd_2.4.0-1_x64-3.2.ipk

TODO:
1. sysout is polluted with logs from **cmd** and **sdk** - they should be redirected to 
2. probably need smarter way for invoking tests during the build:
3. some integration tests are failing (sync?) - needs investigation.

[build.log](https://github.com/user-attachments/files/25241724/build.log)