### PR TITLE
accel-ppp: bump version to 1.14.0-2

### DIFF
--- a/accel-ppp/Makefile
+++ b/accel-ppp/Makefile
@@ -9,8 +9,8 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=accel-ppp
 PKG_VERSION:=1.14.0
-PKG_REV:=6afbc5075a3cf88a47f01c9051dd0a7fdcb06299
-PKG_RELEASE:=1
+PKG_REV:=048d31cb446879e0d1a1471b4ab99135a92bf289
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
@@ -28,7 +28,7 @@ define Package/accel-ppp
 	SECTION:=net
 	CATEGORY:=Network
 	SUBMENU:=VPN
-	DEPENDS:=+libopenssl +libpcre +libpthread +librt
+	DEPENDS:=+libopenssl +libpcre2 +libpthread +librt
 	TITLE:=accel-ppp VPN server
 	URL:=https://accel-ppp.org/
 	MAINTAINER:=Entware team, https://entware.net

--- a/accel-ppp/patches/010-cmake-4x.patch
+++ b/accel-ppp/patches/010-cmake-4x.patch
@@ -1,8 +1,0 @@
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -1,4 +1,4 @@
--cmake_minimum_required(VERSION 2.6)
-+cmake_minimum_required(VERSION 2.6...3.10)
- 
- if (CMAKE_BINARY_DIR STREQUAL CMAKE_HOME_DIRECTORY)
-     message(FATAL_ERROR "Building in source directory is forbidden. Please make separated build directory.")

--- a/accel-ppp/patches/020-config-paths.patch
+++ b/accel-ppp/patches/020-config-paths.patch
@@ -7,7 +7,7 @@
  #log_syslog
  #log_tcp
  #log_pgsql
-@@ -32,7 +32,7 @@ pppd_compat
+@@ -37,7 +37,7 @@ pppd_compat
  #ipv6pool
  
  [core]
@@ -16,7 +16,7 @@
  thread-count=4
  
  [common]
-@@ -104,7 +104,7 @@ interface=eth0
+@@ -109,7 +109,7 @@ interface=eth0
  
  [l2tp]
  verbose=1
@@ -25,7 +25,7 @@
  #hello-interval=60
  #timeout=60
  #rtimeout=1
-@@ -128,13 +128,13 @@ verbose=1
+@@ -133,13 +133,13 @@ verbose=1
  #cert-hash-sha256=
  #accept=ssl,proxy
  #ssl-protocol=tls1,tls1.1,tls1.2,tls1.3
@@ -43,7 +43,7 @@
  #host-name=domain.tld
  #http-error=allow
  #timeout=60
-@@ -181,7 +181,7 @@ start=dhcpv4
+@@ -186,7 +186,7 @@ start=dhcpv4
  #attr-l4-redirect=L4-Redirect
  #attr-l4-redirect-table=4
  #attr-l4-redirect-ipset=l4-redirect
@@ -52,7 +52,7 @@
  #offer-delay=0,100:100,200:200,-1:1000
  #vlan-mon=eth0,10-200
  #vlan-timeout=60
-@@ -206,7 +206,7 @@ interface=eth0
+@@ -211,7 +211,7 @@ interface=eth0
  #wins2=172.16.1.1
  
  [radius]
@@ -61,7 +61,7 @@
  nas-identifier=accel-ppp
  nas-ip-address=127.0.0.1
  gw-ip-address=192.168.100.1
-@@ -242,9 +242,9 @@ attr=Framed-Pool
+@@ -250,9 +250,9 @@ attr=Framed-Pool
  192.168.4.0/24
  
  [log]
@@ -74,7 +74,7 @@
  #log-debug=/dev/stdout
  #syslog=accel-pppd,daemon
  #log-tcp=127.0.0.1:3000
-@@ -261,16 +261,16 @@ log-table=log
+@@ -269,16 +269,16 @@ log-table=log
  
  [pppd-compat]
  verbose=1

--- a/accel-ppp/patches/030-linkage.patch
+++ b/accel-ppp/patches/030-linkage.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -6,7 +6,7 @@ endif ()
+@@ -7,7 +7,7 @@ endif ()
  
  project(accel-ppp C)
  

--- a/accel-ppp/patches/040-ppp-no-modprobe.patch
+++ b/accel-ppp/patches/040-ppp-no-modprobe.patch
@@ -1,6 +1,6 @@
 --- a/accel-pppd/ctrl/l2tp/l2tp.c
 +++ b/accel-pppd/ctrl/l2tp/l2tp.c
-@@ -5003,8 +5003,6 @@ static void l2tp_init(void)
+@@ -5083,8 +5083,6 @@ static void l2tp_init(void)
  	fd = socket(AF_PPPOX, SOCK_DGRAM, PX_PROTO_OL2TP);
  	if (fd >= 0)
  		close(fd);
@@ -11,7 +11,7 @@
  	memset(l2tp_conn, 0, (UINT16_MAX + 1) * sizeof(struct l2tp_conn_t *));
 --- a/accel-pppd/ctrl/pppoe/pppoe.c
 +++ b/accel-pppd/ctrl/pppoe/pppoe.c
-@@ -2117,8 +2117,6 @@ static void pppoe_init(void)
+@@ -2137,8 +2137,6 @@ static void pppoe_init(void)
  	fd = socket(AF_PPPOX, SOCK_STREAM, PX_PROTO_OE);
  	if (fd >= 0)
  		close(fd);

--- a/accel-ppp/patches/040-ppp-no-modprobe.patch
+++ b/accel-ppp/patches/040-ppp-no-modprobe.patch
@@ -31,3 +31,36 @@
  
  	serv.hnd.fd = socket(PF_INET, SOCK_STREAM, 0);
  	if (serv.hnd.fd < 0) {
+--- a/accel-pppd/ctrl/ipoe/ipoe_netlink.c
++++ b/accel-pppd/ctrl/ipoe/ipoe_netlink.c
+@@ -624,7 +624,7 @@ static void init(void)
+ {
+	int mcg_id;
+
+-	if (access("/sys/module/ipoe", F_OK) && system("modprobe -q ipoe"))
++	if (access("/sys/module/ipoe", F_OK))
+		log_warn("failed to load ipoe module\n");
+
+	mcg_id = genl_resolve_mcg(IPOE_GENL_NAME, IPOE_GENL_MCG_PKT, &ipoe_genl_id);
+--- a/accel-pppd/shaper/limiter.c
++++ b/accel-pppd/shaper/limiter.c
+@@ -636,8 +636,6 @@ static int init_htb(const char *name)
+		.qdisc = qdisc_htb_root,
+	};
+
+-	if (system("modprobe -q ifb"))
+-		log_warn("failed to load ifb kernel module\n");
+
+	memset(&ifr, 0, sizeof(ifr));
+	strcpy(ifr.ifr_name, name);
+--- a/accel-pppd/vlan-mon/vlan_mon.c
++++ b/accel-pppd/vlan-mon/vlan_mon.c
+@@ -522,7 +522,7 @@ static void init(void)
+ {
+	int mcg_id;
+
+-	if (access("/sys/module/vlan_mon", F_OK) && system("modprobe -q vlan_mon"))
++	if (access("/sys/module/vlan_mon", F_OK))
+		log_warn("failed to load vlan_mon module\n");
+
+	mcg_id = genl_resolve_mcg(VLAN_MON_GENL_NAME, VLAN_MON_GENL_MCG, &vlan_mon_genl_id);

--- a/accel-ppp/patches/060-paths.patch
+++ b/accel-ppp/patches/060-paths.patch
@@ -1,6 +1,6 @@
 --- a/accel-pppd/extra/chap-secrets.c
 +++ b/accel-pppd/extra/chap-secrets.c
-@@ -20,7 +20,7 @@
+@@ -21,7 +21,7 @@
  
  #include "memdebug.h"
  

--- a/accel-ppp/patches/060-paths.patch
+++ b/accel-ppp/patches/060-paths.patch
@@ -9,3 +9,37 @@
  static char *conf_chap_secrets;
  static int conf_encrypted;
  static in_addr_t conf_gw_ip_address = 0;
+--- a/accel-pppd/cli/telnet.c
++++ b/accel-pppd/cli/telnet.c
+@@ -69,7 +69,7 @@ static uint8_t *recv_buf;
+ static uint8_t *temp_buf;
+
+ static int conf_history_len = 100;
+-static const char *conf_history_file = "/var/lib/accel-ppp/history";
++static const char *conf_history_file = "/opt/var/lib/accel-ppp/history";
+ static int conf_verbose;
+
+ static LIST_HEAD(history);
+--- a/accel-pppd/net.c
++++ b/accel-pppd/net.c
+@@ -448,7 +448,7 @@ void net_init()
+	if (opt)
+		conf_netns_run_dir = opt;
+	else
+-		conf_netns_run_dir = "/var/run/netns";
++		conf_netns_run_dir = "/opt/var/run/netns";
+
+	def_net = net = alloc_net(NULL);
+ }
+--- a/accel-pppd/session.c
++++ b/accel-pppd/session.c
+@@ -541,7 +541,7 @@ void session_init()
+		conf_sid_source = SID_SOURCE_SEQ;
+
+	conf_seq_file = conf_get_opt("common", "seq-file");
+	if (!conf_seq_file)
+-		conf_seq_file = "/var/lib/accel-ppp/seq";
++		conf_seq_file = "/opt/var/lib/accel-ppp/seq";
+
+	opt = conf_get_opt("common", "max-sessions");
+	if (opt)


### PR DESCRIPTION
Hello. I asked Google Jules to bump accel-ppp. Note the change in dependencies (`libpcre` -> `libpcre2`) and refreshed patches. 

Note that PKG_MIRROR_HASH needs an update. I'm leaving that to the maintainers. Similarly, I didn't bother setting up a build system, so this PR is currently untested even for compilation. The two possible failure modes I can think of, are 1.) the patches did not refresh correctly 2.) upstream introduced a new incompatibility somewhere that was not caught. (I did not ask the AI to scan the upstream repository; I'lI do that now.) 
 
 -------
Here's the changelog generated by the AI:
- Update PKG_REV to official 1.14.0 tag (048d31c)
- Increment PKG_RELEASE to 2
- Update dependency from libpcre to libpcre2
- Remove redundant 010-cmake-4x.patch (upstream now requires 3.10)
- Refresh remaining patches for 1.14.0 compatibility

Fixes: https://github.com/Entware/Entware/issues/1217
--------
Compile tested: none
Run tested: none

Can test compiled packages on: aarch64-k3.10 asuswrt-merlin AX86U
