### PR TITLE
Fix building packages with CONFIG_AUTOREMOVE

### DIFF
--- a/espeak-ng/Makefile
+++ b/espeak-ng/Makefile
@@ -4,6 +4,8 @@
 
 include $(TOPDIR)/rules.mk
 
+override CONFIG_AUTOREMOVE=
+
 PKG_NAME:=espeak-ng
 PKG_VERSION:=1.52
 PKG_REV:=4870adfa25b1a32b4361592f1be8a40337c58d6c

--- a/ghostscript/Makefile
+++ b/ghostscript/Makefile
@@ -10,6 +10,8 @@
 
 include $(TOPDIR)/rules.mk
 
+override CONFIG_AUTOREMOVE=
+
 PKG_NAME:=ghostscript
 PKG_VERSION:=10.01.2
 PKG_RELEASE:=1

--- a/gutenprint/Makefile
+++ b/gutenprint/Makefile
@@ -6,6 +6,8 @@
 
 include $(TOPDIR)/rules.mk
 
+override CONFIG_AUTOREMOVE=
+
 PKG_NAME:=gutenprint
 PKG_VERSION:=5.3.5
 PKG_RELEASE:=1

--- a/nethack/Makefile
+++ b/nethack/Makefile
@@ -7,6 +7,8 @@
 
 include $(TOPDIR)/rules.mk
 
+override CONFIG_AUTOREMOVE=
+
 PKG_NAME:=nethack
 PKG_VERSION:=3.6.7
 PKG_RELEASE:=1

--- a/telegram-cli/Makefile
+++ b/telegram-cli/Makefile
@@ -8,6 +8,8 @@
 
 include $(TOPDIR)/rules.mk
 
+override CONFIG_AUTOREMOVE=
+
 PKG_NAME:=telegram-cli
 PKG_VERSION:=1.3.1-20160323
 PKG_REV:=6547c0b21b977b327b3c5e8142963f4bc246187a


### PR DESCRIPTION
This PR fixes building some of packages with enabled `CONFIG_AUTOREMOVE` (disables `CONFIG_AUTOREMOVE` for several packages where need to store cache in `build_dir` folder because this cache required for code generation / for dependent packages)